### PR TITLE
Add context processor for current year

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -73,4 +73,9 @@ def create_app(config_class=DevelopmentConfig):
         app.logger.setLevel(logging.INFO)
         app.logger.info("Urgentias startup")
 
+    @app.context_processor
+    def inject_current_year():
+        """Agrega el año actual al contexto de las plantillas."""
+        return {"current_year": datetime.now().year}
+
     return app


### PR DESCRIPTION
## Summary
- inject `current_year` into templates via context processor

## Testing
- `python -m py_compile app/__init__.py`
- `python -m pytest -q` *(fails: No module named pytest)*
- `python manage.py --help` *(fails: cannot import name 'GetCoreSchemaHandler' from 'pydantic')*